### PR TITLE
Add "opencv-python" in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ networkx
 scipy
 numpy
 toolz
+opencv-python


### PR DESCRIPTION
It is good practice to install pip requirements in a virtualenv. When I tried installing it in virtualenv, I got `module 'cv2' not found` error. This solves it. Simple. :)